### PR TITLE
Fix: Pass required object 'env'.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ const infoRegexp = /^plantuml(?:@(.+))?:([\w-_.]+)/;
 
 function puFromMd(markdown) {
     const md = new markdownit();
-    const fences = md.parse(markdown)
+    const fences = md.parse(markdown, {})
         .filter(token => token.type === 'fence')
         .filter(token => infoRegexp.test(token.info));
 


### PR DESCRIPTION
resolve #2 

Have forgot to pass required parameter 'env' to `MarkdownIt.parse`.

