### PR TITLE
Update action.yml to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'the commit message when committing generated images'
     default: 'Render PlantUML files'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'image'


### PR DESCRIPTION
- #44

![Screenshot from 2023-03-19 11-26-43](https://user-images.githubusercontent.com/3270997/226198879-c508e4ff-d596-4d23-baca-8a9762165989.png)


[plantuml](https://github.com/grassedge/generate-plantuml-action/actions/runs/3386743029/jobs/5626541623)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, grassedge/generate-plantuml-action, actions/checkout